### PR TITLE
fix mobile warping on splash page

### DIFF
--- a/frontend/src/components/nav/navbar.css
+++ b/frontend/src/components/nav/navbar.css
@@ -285,8 +285,30 @@ footer {
 		 overflow: auto;
 	} */
 
-
-
+/* Fix Mobile Warping on Splash */
+  @media screen and (max-width:700px){
+     html {
+      overflow-x: hidden;
+    }
+    .splash-ani {
+      max-height:160px;
+    }
+    .splash-ani-container {
+      max-height:160px;
+    }
+    .nav-right {
+      padding: 0%;
+    }
+    .nav-right .grey-button {
+      transform: scale(.85);
+    }
+    .nav-right .blue-button {
+      transform: scale(.85);
+    }
+    .nav-right .pink-button {
+      transform: scale(.85);
+    }
+}
 
 
 


### PR DESCRIPTION
added css for mobile screen size to fix right spacing/ splash image warping on mobile screens. DevTools okay - need to verify on live after heroku push.